### PR TITLE
fixed multi sortOrder bug in LexalParser

### DIFF
--- a/MonoDevelop.VersionControl.TFS/Microsoft.TeamFoundation.WorkItemTracking.Client/Query/LexalParser.cs
+++ b/MonoDevelop.VersionControl.TFS/Microsoft.TeamFoundation.WorkItemTracking.Client/Query/LexalParser.cs
@@ -462,8 +462,9 @@ namespace Microsoft.TeamFoundation.WorkItemTracking.Client.Query
             {
                 var orderByItems = orderByClause.Split(new [] { "," }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var item in orderByItems)
-                {
-                    var parts = item.Split(new [] { " " }, StringSplitOptions.RemoveEmptyEntries);
+                { 
+                    var tmpItem = item.Trim();
+                    var parts = tmpItem.Split(new [] { " " }, StringSplitOptions.RemoveEmptyEntries);
                     if (parts.Length == 1)
                         list.Add(new OrderByNode(parts[0], Direction.Asc));
                     if (parts.Length == 2)


### PR DESCRIPTION
Fixed bug when multiple sort orders have to be parsed. Bug reported in issue https://github.com/Indomitable/monodevelop-tfs-addin/issues/2

Example:

``` SQL
    SELECT [System.Id], 
           [Microsoft.VSTS.Common.StackRank], 
           [Microsoft.VSTS.Common.Priority], 
           [System.State], 
           [Microsoft.VSTS.Scheduling.RemainingWork], 
           [Microsoft.VSTS.Scheduling.CompletedWork], 
           [System.Title] 
      FROM WorkItems 
     WHERE [System.TeamProject] = @project 
       AND [System.AssignedTo] = @me 
       AND [System.WorkItemType] = 'Aufgabe' 
       AND [System.State] <> 'Geschlossen' 
       AND [System.State] <> 'Entfernt' 
  ORDER BY [System.State], 
           [Microsoft.VSTS.Common.StackRank], 
           [Microsoft.VSTS.Common.Priority], 
           [System.Id]
```

Linefeed at the beginning splits order by statement into two elements.
![capturfiles_32](https://cloud.githubusercontent.com/assets/5220162/5354214/3850060e-7f85-11e4-9d83-6d81039e581d.jpg)
